### PR TITLE
Fix bug read empty json file (really empty)

### DIFF
--- a/dbc/json/json_query.go
+++ b/dbc/json/json_query.go
@@ -105,7 +105,7 @@ func (q *Query) Cursor(in toolkit.M) (dbox.ICursor, error) {
 
 		if !ok {
 			return nil, errorlib.Error(packageName,
-				modQuery, "Cursor", e.Error())
+				modQuery, "Cursor", "the file contains invalid json data")
 		}
 		cursor.(*Cursor).count = len(count)
 		if fields != nil {


### PR DESCRIPTION
when trying to read a json file **which have empty contents** (not `[]`, but really empty file), an error occurred. this PR will solve that.

```
2015/12/23 16:08:08 http: panic serving 127.0.0.1:58879: runtime error: invalid memory address or nil pointer dereference
goroutine 34 [running]:
net/http.(*conn).serve.func1(0xc820172000, 0xda1198, 0xc820158010)
	/usr/local/go/src/net/http/server.go:1287 +0xb5
github.com/eaciit/dbox/dbc/json.(*Query).Cursor(0xc82014c360, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/novalagung/Documents/go/src/github.com/eaciit/dbox/dbc/json/json_query.go:107 +0xd57
main.(*TemplateController).GetChartConfigs(0xc820071770, 0xc82004b7b0, 0x0, 0x0)
	/Users/novalagung/Documents/go/src/github.com/eaciit/webtemplate/webtemplate.go:289 +0x550
main.(*TemplateController).SaveChartConfig(0xc820071770, 0xc8201521e0, 0x0, 0x0)
	/Users/novalagung/Documents/go/src/github.com/eaciit/webtemplate/webtemplate.go:315 +0x34b
reflect.callMethod(0xc82011fad0, 0xc82004b990)
	/usr/local/go/src/reflect/value.go:628 +0x1fc
reflect.methodValueCall(0xc8201521e0, 0xc8201521e0, 0xc82009f290, 0x0, 0xc820150660, 0x10e4bc, 0x794860, 0xc820096a50, 0xc82015e2d0, 0xc8201521e0, ...)
	/usr/local/go/src/reflect/asm_amd64.s:29 +0x36
github.com/eaciit/knot/knot%2ev1.(*Server).RouteWithConfig.func1(0xda1318, 0xc8201720b0, 0xc820178000)
	/Users/novalagung/Documents/go/src/github.com/eaciit/knot/knot.v1/server.go:152 +0x25a
net/http.HandlerFunc.ServeHTTP(0xc82012c5e0, 0xda1318, 0xc8201720b0, 0xc820178000)
	/usr/local/go/src/net/http/server.go:1422 +0x3a
github.com/gorilla/mux.(*Router).ServeHTTP(0xc820096c80, 0xda1318, 0xc8201720b0, 0xc820178000)
	/Users/novalagung/Documents/go/src/github.com/gorilla/mux/mux.go:98 +0x29e
net/http.serverHandler.ServeHTTP(0xc82014c000, 0xda1318, 0xc8201720b0, 0xc820178000)
	/usr/local/go/src/net/http/server.go:1862 +0x19e
net/http.(*conn).serve(0xc820172000)
	/usr/local/go/src/net/http/server.go:1361 +0xbee
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:1910 +0x3f6
^Cexit status 2
```